### PR TITLE
Rename c-sources to cmm-sources for Cabal 3.10.2.0 (#9200)

### DIFF
--- a/heapsize.cabal
+++ b/heapsize.cabal
@@ -1,4 +1,4 @@
-cabal-version:      2.0
+cabal-version:      3.0
 name:               heapsize
 version:            0.3.0.1
 license:            BSD3
@@ -16,7 +16,7 @@ description:        heapsize is a tool to determine the size data structures.
 Library
   Exposed-modules:
     HeapSize
-  c-sources:
+  cmm-sources:
     cbits/heapsize_prim.cmm
   Default-Language: Haskell2010
   Build-depends:


### PR DESCRIPTION
@pepeiborra 
Cabal 3.10.2.0 ([haskell/cabal#9200](https://github.com/haskell/cabal/pull/9200)), included with GHC 9.8.1, only supports `.c` files in a `c-sources` field. This leads to a linker error and fails the build. Since version 3.0, a different field `cmm-sources` is supported specifically for `.cmm` source files.

The requirements are relaxed a bit in Cabal 3.10.2.1 ([haskell/cabal#9285](https://github.com/haskell/cabal/pull/9285)), but the change is still intended, so this PR is at least future-proofing the situation.

#### Appendix
```
Configuring heapsize-0.3.0.1...
Preprocessing library for heapsize-0.3.0.1..
Building library for heapsize-0.3.0.1..
[1 of 1] Compiling HeapSize         ( src/HeapSize.hs, dist/build/HeapSize.dyn_o )
/usr/bin/ld.gold: error: cannot open dist/build/cbits/heapsize_prim.dyn_o: No such file or directory
collect2: error: ld returned 1 exit status
`gcc' failed in phase `Linker'. (Exit code: 1)
```